### PR TITLE
Fix transformer generator default param arguments

### DIFF
--- a/src/FxKit.CompilerServices.Tests/FxKit.CompilerServices.Tests.csproj
+++ b/src/FxKit.CompilerServices.Tests/FxKit.CompilerServices.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Basic.Reference.Assemblies.Net80" Version="1.7.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -22,7 +22,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0"/>
     <PackageReference Include="NUnit" Version="4.1.0"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
@@ -34,8 +34,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Verify" Version="24.2.0"/>
-    <PackageReference Include="Verify.NUnit" Version="24.2.0"/>
+    <PackageReference Include="Verify" Version="25.0.3" />
+    <PackageReference Include="Verify.NUnit" Version="25.0.3" />
     <PackageReference Remove="MinVer"/>
   </ItemGroup>
 

--- a/src/FxKit.CompilerServices.Tests/FxKit.CompilerServices.Tests.csproj
+++ b/src/FxKit.CompilerServices.Tests/FxKit.CompilerServices.Tests.csproj
@@ -48,6 +48,9 @@
     <None Update="UnitTests\CodeGenerators\TransformerGeneratorReferencedAssembliesTests.IncludesFunctorsAndBehaviorFromReferencedAssemblies.verified.txt">
       <DependentUpon>TransformerGeneratorReferencedAssembliesTests.cs</DependentUpon>
     </None>
+    <None Update="UnitTests\CodeGenerators\TransformerGeneratorTests.PreservesParameterDefault.verified.txt">
+      <DependentUpon>TransformerGeneratorTests.cs</DependentUpon>
+    </None>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.PreservesParameterDefault.verified.txt
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.PreservesParameterDefault.verified.txt
@@ -1,0 +1,26 @@
+﻿using App;
+using System;
+using System.Threading.Tasks;
+using TaskExtensions;
+
+#nullable enable
+namespace Monads
+{
+    public static class ResultT
+    {
+        /// <summary>
+        ///     <c>Task</c> of <c>Result</c> Transformer Method for <c>Map</c>.
+        /// </summary>
+        public static Task<Result<TNewOk, TErr>> MapT<TOk, TErr, TNewOk>(this Task<Result<TOk, TErr>> source, Func<TOk, TNewOk> selector)
+            where TOk : notnull where TErr : notnull where TNewOk : notnull => source.Map(inner => inner.Map(selector));
+        /// <summary>
+        ///     <c>Task</c> of <c>Result</c> Transformer Method for <c>Unwrap</c>.
+        /// </summary>
+        public static Task<TOk> UnwrapT<TOk, TErr>(this Task<Result<TOk, TErr>> source, string? exceptionMessage = null)
+            where TOk : notnull where TErr : notnull => source.Map(inner => inner.Unwrap(exceptionMessage));
+    }
+}
+
+-------------
+
+[assembly: FxKit.CompilerServices.ContainsFunctors]

--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
@@ -247,6 +247,51 @@ public class TransformerGeneratorTests
         await output.VerifyGeneratedCode();
     }
 
+    [Test]
+    public async Task PreservesParameterDefault()
+    {
+        var output = Generate(
+            $$"""
+                {{ResultTypeAndImplementation}}
+
+                namespace App
+                {
+                  using System;
+                  using System.Collections.Generic;
+                  using FxKit.CompilerServices;
+                  using Monads;
+                  using StringAlias = string;
+
+                  public static class ResultExtensions
+                  {
+                      [GenerateTransformer]
+                      public static TOk Unwrap<TOk, TErr>(
+                          this Result<TOk, TErr> source,
+                          StringAlias? exceptionMessage = null)
+                          where TOk : notnull
+                          where TErr : notnull
+                          => throw new NotImplementedException();
+                  }
+                }
+
+                namespace TaskExtensions
+                {
+                    using System;
+                    using System.Threading.Tasks;
+                    using System.Collections.Generic;
+
+                    public static class E
+                    {
+                        public static async Task<U> Map<T, U>(
+                            this Task<T> source,
+                            Func<T, U> selector) => selector(await source);
+                    }
+                }
+            """);
+
+        await output.VerifyGeneratedCode();
+    }
+
     private static string Generate(string source) =>
         CodeGeneratorTestUtil.GetGeneratedOutput(new TransformerGenerator(), source);
 }

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerClassBuilder.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerClassBuilder.cs
@@ -337,7 +337,18 @@ internal static class TransformerClassBuilder
                         method.Parameters
                             .Select(
                                 static p =>
-                                    Parameter(ParseToken(p.Name)).WithType(ParseTypeName(p.Type))))));
+                                {
+                                    var parameter = Parameter(Identifier(p.Name))
+                                        .WithType(ParseTypeName(p.TypeFullName));
+
+                                    if (p.Default is not null)
+                                    {
+                                        return parameter.WithDefault(
+                                            EqualsValueClause(ParseExpression(p.Default)));
+                                    }
+
+                                    return parameter;
+                                }))));
     }
 
     /// <summary>
@@ -361,8 +372,7 @@ internal static class TransformerClassBuilder
                         .WithArgumentList(
                             ArgumentList(
                                 SeparatedList(
-                                    method.Parameters.Select(
-                                        x => Argument(IdentifierName(x.Name)))))));
+                                    method.Parameters.Select(x => Argument(IdentifierName(x.Name)))))));
 
         var bodyExpression = InvocationExpression(
                 MemberAccessExpression(

--- a/src/FxKit.Tests/FxKit.Tests.csproj
+++ b/src/FxKit.Tests/FxKit.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0"/>
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3">
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
The previous PR didn't account for default arguments in parameters like `public static void Method(string parameter = "default value")`.

