### PR TITLE
Further improvements in `TransformerGenerator`

### DIFF
--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.GeneratesTransformers.verified.txt
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.GeneratesTransformers.verified.txt
@@ -19,6 +19,11 @@ namespace Monads
         public static Validation<TOk, TInvalid> UnwrapT<TOk, TErr, TInvalid>(this Validation<Result<TOk, TErr>, TInvalid> source)
             where TOk : notnull where TErr : notnull where TInvalid : notnull => source.Map(inner => inner.Unwrap());
         /// <summary>
+        ///     <c>Validation</c> of <c>Result</c> Transformer Method for <c>FlatMapAsync</c>.
+        /// </summary>
+        public static Validation<Task<Result<TNewOk, TErr>>, TInvalid> FlatMapAsyncT<TOk, TErr, TNewOk, TInvalid>(this Validation<Result<TOk, TErr>, TInvalid> source, Func<TOk, Task<Result<TNewOk, TErr>>> selector)
+            where TOk : notnull where TErr : notnull where TNewOk : notnull where TInvalid : notnull => source.Map(inner => inner.FlatMapAsync(selector));
+        /// <summary>
         ///     <c>Task</c> of <c>Result</c> Transformer Method for <c>Map</c>.
         /// </summary>
         public static Task<Result<TNewOk, TErr>> MapT<TOk, TErr, TNewOk>(this Task<Result<TOk, TErr>> source, Func<TOk, TNewOk> selector)
@@ -28,6 +33,11 @@ namespace Monads
         /// </summary>
         public static Task<TOk> UnwrapT<TOk, TErr>(this Task<Result<TOk, TErr>> source)
             where TOk : notnull where TErr : notnull => source.Map(inner => inner.Unwrap());
+        /// <summary>
+        ///     <c>Task</c> of <c>Result</c> Transformer Method for <c>FlatMapAsync</c>.
+        /// </summary>
+        public static Task<Result<TNewOk, TErr>> FlatMapAsyncT<TOk, TErr, TNewOk>(this Task<Result<TOk, TErr>> source, Func<TOk, Task<Result<TNewOk, TErr>>> selector)
+            where TOk : notnull where TErr : notnull where TNewOk : notnull => source.Map(inner => inner.FlatMapAsync(selector)).Unwrap();
         /// <summary>
         ///     <c>IEnumerable</c> of <c>Result</c> Transformer Method for <c>Map</c>.
         /// </summary>
@@ -39,6 +49,11 @@ namespace Monads
         public static IEnumerable<TOk> UnwrapT<TOk, TErr>(this IEnumerable<Result<TOk, TErr>> source)
             where TOk : notnull where TErr : notnull => source.Map(inner => inner.Unwrap());
         /// <summary>
+        ///     <c>IEnumerable</c> of <c>Result</c> Transformer Method for <c>FlatMapAsync</c>.
+        /// </summary>
+        public static IEnumerable<Task<Result<TNewOk, TErr>>> FlatMapAsyncT<TOk, TErr, TNewOk>(this IEnumerable<Result<TOk, TErr>> source, Func<TOk, Task<Result<TNewOk, TErr>>> selector)
+            where TOk : notnull where TErr : notnull where TNewOk : notnull => source.Map(inner => inner.FlatMapAsync(selector));
+        /// <summary>
         ///     <c>IReadOnlyList</c> of <c>Result</c> Transformer Method for <c>Map</c>.
         /// </summary>
         public static IReadOnlyList<Result<TNewOk, TErr>> MapT<TOk, TErr, TNewOk>(this IReadOnlyList<Result<TOk, TErr>> source, Func<TOk, TNewOk> selector)
@@ -48,6 +63,11 @@ namespace Monads
         /// </summary>
         public static IReadOnlyList<TOk> UnwrapT<TOk, TErr>(this IReadOnlyList<Result<TOk, TErr>> source)
             where TOk : notnull where TErr : notnull => source.Map(inner => inner.Unwrap());
+        /// <summary>
+        ///     <c>IReadOnlyList</c> of <c>Result</c> Transformer Method for <c>FlatMapAsync</c>.
+        /// </summary>
+        public static IReadOnlyList<Task<Result<TNewOk, TErr>>> FlatMapAsyncT<TOk, TErr, TNewOk>(this IReadOnlyList<Result<TOk, TErr>> source, Func<TOk, Task<Result<TNewOk, TErr>>> selector)
+            where TOk : notnull where TErr : notnull where TNewOk : notnull => source.Map(inner => inner.FlatMapAsync(selector));
     }
 }
 

--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
@@ -205,8 +205,11 @@ public class TransformerGeneratorTests
             compilation,
             out _,
             out var diagnostics);
-        diagnostics.Should().HaveCount(1);
+        diagnostics.Should().HaveCount(expected: 2, because: "one for each map method");
         diagnostics[0]
+            .Descriptor.Should()
+            .Be(DiagnosticsDescriptors.MethodDeclarationCannotAllowCollidingTypeParameters);
+        diagnostics[1]
             .Descriptor.Should()
             .Be(DiagnosticsDescriptors.MethodDeclarationCannotAllowCollidingTypeParameters);
     }

--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/TransformerGeneratorTests.cs
@@ -63,14 +63,22 @@ public class TransformerGeneratorTests
                     public static Result<TNewOk, TErr> Map<TOk, TErr, TNewOk>(
                         this Result<TOk, TErr> source,
                         Func<TOk, TNewOk> selector)
-                    where TOk : notnull
-                    where TNewOk : notnull
-                    where TErr : notnull  => throw new NotImplementedException();
+                        where TOk : notnull
+                        where TNewOk : notnull
+                        where TErr : notnull  => throw new NotImplementedException();
 
                     [GenerateTransformer]
                     public static TOk Unwrap<TOk, TErr>(this Result<TOk, TErr> result)
-                    where TOk : notnull
-                    where TErr : notnull => throw new NotImplementedException();
+                        where TOk : notnull
+                        where TErr : notnull => throw new NotImplementedException();
+
+                    [GenerateTransformer]
+                    public static Task<Result<TNewOk, TErr>> FlatMapAsync<TOk, TErr, TNewOk>(
+                        this Result<TOk, TErr> source,
+                        Func<TOk, Task<Result<TNewOk, TErr>>> selector)
+                        where TOk : notnull
+                        where TErr : notnull
+                        where TNewOk : notnull => throw new NotImplementedException();
                 }
 
                 public static class Validation

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/ConcreteOrConstructedType.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/ConcreteOrConstructedType.cs
@@ -5,25 +5,24 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 namespace FxKit.CompilerServices.CodeGenerators.Transformers;
 
 /// <summary>
-///     Represents a method return type - either a concrete type or a constructed
-///     type from a generic type.
+///     Represents either a concrete type, or a type constructed from a generic type.
 /// </summary>
-internal abstract record ReturnType
+internal abstract record ConcreteOrConstructedType
 {
     /// <summary>
     ///     A constructed generic return type (e.g <c>Option&lt;int&gt;</c>).
     /// </summary>
-    internal sealed record Constructed(ConstructedType ConstructedType) : ReturnType
+    internal sealed record Constructed(ConstructedType ConstructedType) : ConcreteOrConstructedType
     {
-        public static ReturnType Of(ConstructedType constructedType) => new Constructed(constructedType);
+        public static ConcreteOrConstructedType Of(ConstructedType constructedType) => new Constructed(constructedType);
     }
 
     /// <summary>
     ///     A concrete return type (e.g <c>int</c>).
     /// </summary>
-    internal sealed record Concrete(ConcreteType Type) : ReturnType
+    internal sealed record Concrete(ConcreteType Type) : ConcreteOrConstructedType
     {
-        public static ReturnType Of(ConcreteType type) => new Concrete(type);
+        public static ConcreteOrConstructedType Of(ConcreteType type) => new Concrete(type);
     }
 }
 

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/Functor.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/Functor.cs
@@ -27,8 +27,8 @@ internal sealed record ReferencedFunctors(
     ///     Finds functors and functor implementations in the given assembly reference.
     /// </summary>
     /// <remarks>
-    ///     We're extracting both functors (typed with a `[Functor]` attribute), as well
-    ///     as functor implementations (`Map` methods) in a single pass to avoid having
+    ///     We're extracting both functors (typed with a `[Functor]` attribute),
+    ///     as well as functor implementations (`Map` methods) in a single pass to avoid having
     ///     to iterate on references multiple times.
     /// </remarks>
     /// <param name="reference"></param>
@@ -54,7 +54,7 @@ internal sealed record ReferencedFunctors(
             foreach (var attributeData in typeSymbol.GetAttributes())
             {
                 if (attributeData.AttributeClass?.GetFullyQualifiedMetadataName() !=
-                    TransformerGenerator.FunctorAttribute)
+                    FunctorAttributeFullyQualifiedName)
                 {
                     continue;
                 }

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/FunctorMethodDescriptor.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/FunctorMethodDescriptor.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using FxKit.CompilerServices.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -110,22 +111,14 @@ internal sealed record FunctorMethodDescriptor
                 $"Can't create a {nameof(FunctorMethodDescriptor)} from a method with no parameters.");
         }
 
-        var thisParamContainingNamespace =
-            symbol.Parameters[0].Type.ContainingNamespace.ToDisplayString();
-
         // The first parameter to a method is always the functor itself.
-        var containerReference = ConstructedType.From(
-            value: Unsafe.As<GenericNameSyntax>(method.ParameterList.Parameters.First().Type!),
-            containingNamespace: thisParamContainingNamespace);
+        Debug.Assert(
+            symbol.Parameters[0].Type is INamedTypeSymbol,
+            "symbol.Parameters[0].Type is INamedTypeSymbol");
+        var firstMethodParameterType = Unsafe.As<INamedTypeSymbol>(symbol.Parameters[0].Type);
+        var containerReference = ConstructedType.From(firstMethodParameterType);
 
-        var returnType = method.ReturnType switch
-        {
-            GenericNameSyntax gns => ConcreteOrConstructedType.Constructed.Of(
-                constructedType: ConstructedType.From(
-                    value: gns,
-                    containingNamespace: symbol.ReturnType.ContainingNamespace.ToDisplayString())),
-            _ => ConcreteOrConstructedType.Concrete.Of(type: ConcreteType.From(method.ReturnType))
-        };
+        var returnType = ConcreteOrConstructedType.FromTypeSymbol(symbol.ReturnType);
 
         // The namespaces that the method uses.
         var requiredNamespaces = symbol.Parameters

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/FunctorMethodDescriptor.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/FunctorMethodDescriptor.cs
@@ -18,7 +18,7 @@ internal sealed record FunctorMethodDescriptor
     /// <summary>
     ///     The return type of this method.
     /// </summary>
-    public ReturnType ReturnType { get; }
+    public ConcreteOrConstructedType ReturnType { get; }
 
     /// <summary>
     ///     The name of this method.
@@ -55,7 +55,7 @@ internal sealed record FunctorMethodDescriptor
 
     private FunctorMethodDescriptor(
         ConstructedType functor,
-        ReturnType returnType,
+        ConcreteOrConstructedType returnType,
         string name,
         EquatableArray<string> typeParameters,
         EquatableArray<FunctorMethodParameter> parameters,
@@ -120,11 +120,11 @@ internal sealed record FunctorMethodDescriptor
 
         var returnType = method.ReturnType switch
         {
-            GenericNameSyntax gns => ReturnType.Constructed.Of(
+            GenericNameSyntax gns => ConcreteOrConstructedType.Constructed.Of(
                 constructedType: ConstructedType.From(
                     value: gns,
                     containingNamespace: symbol.ReturnType.ContainingNamespace.ToDisplayString())),
-            _ => ReturnType.Concrete.Of(type: ConcreteType.From(method.ReturnType))
+            _ => ConcreteOrConstructedType.Concrete.Of(type: ConcreteType.From(method.ReturnType))
         };
 
         // The namespaces that the method uses.

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/Helpers.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/Helpers.cs
@@ -14,6 +14,27 @@ namespace FxKit.CompilerServices.CodeGenerators.Transformers;
 /// </summary>
 internal static class Helpers
 {
+    public const string GenerateTransformerAttributeFullyQualifiedName =
+        "FxKit.CompilerServices.GenerateTransformerAttribute";
+
+    public const string ContainsFunctorsAttributeFullyQualifiedName =
+        "FxKit.CompilerServices.ContainsFunctorsAttribute";
+
+    public const string FunctorAttributeFullyQualifiedName = "FxKit.CompilerServices.FunctorAttribute";
+    public const string IEnumerableFullyQualifiedName      = "System.Collections.Generic.IEnumerable";
+    public const string IReadOnlyListFullyQualifiedName    = "System.Collections.Generic.IReadOnlyList";
+
+    public const string ThisParameterName = "source";
+    public const string InnerFunctorName  = "inner";
+    public const string FunctorMap        = "Map";
+    public const string FunctorFlatten    = "Unwrap";
+    public const string Traverse          = "Traverse";
+    public const string Sequence          = "Sequence";
+
+    public const string LinqMonadicBind = "SelectMany";
+    public const string LinqFilterName  = "Where";
+    public const string CSharpTaskMonad = "Task";
+
     /// <summary>
     ///     Checks whether the specified <paramref name="reference"/>
     ///     contains functor definitions and/or `Map` implementations by scanning for the
@@ -99,7 +120,7 @@ internal static class Helpers
             }
 
             var name = attr.GetFullyQualifiedMetadataName();
-            if (name == TransformerGenerator.ContainsFunctorsAttribute)
+            if (name == ContainsFunctorsAttributeFullyQualifiedName)
             {
                 return true;
             }
@@ -138,7 +159,7 @@ internal static class Helpers
                 var containingTypeName = metadataReader.GetString(containingType.Name);
                 var containingTypeNamespace = metadataReader.GetString(containingType.Namespace);
                 var fullName = $"{containingTypeNamespace}.{containingTypeName}";
-                if (fullName == TransformerGenerator.ContainsFunctorsAttribute)
+                if (fullName == ContainsFunctorsAttributeFullyQualifiedName)
                 {
                     return true;
                 }

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerClassBuilder.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerClassBuilder.cs
@@ -15,20 +15,6 @@ namespace FxKit.CompilerServices.CodeGenerators.Transformers;
 /// </summary>
 internal static class TransformerClassBuilder
 {
-    private const string IEnumerableFullyQualifiedName   = "System.Collections.Generic.IEnumerable";
-    private const string IReadOnlyListFullyQualifiedName = "System.Collections.Generic.IReadOnlyList";
-
-    private const string ThisParameterName = "source";
-    private const string InnerFunctorName  = "inner";
-    private const string FunctorMap        = "Map";
-    private const string FunctorFlatten    = "Unwrap";
-    private const string Traverse          = "Traverse";
-    private const string Sequence          = "Sequence";
-
-    private const string LinqMonadicBind = "SelectMany";
-    private const string LinqFilterName  = "Where";
-    private const string CSharpTaskMonad = "Task";
-
     /// <summary>
     ///     Creates the transformer class and namespace.
     /// </summary>
@@ -79,7 +65,7 @@ internal static class TransformerClassBuilder
                 if (method.Name is Traverse or Sequence)
                 {
                     // Skip over `Traverse`/`Sequence` methods that would nest two of the same functors.
-                    if (method.ReturnType is ReturnType.Constructed f &&
+                    if (method.ReturnType is ConcreteOrConstructedType.Constructed f &&
                         f.ConstructedType.FullyQualifiedName == outer.FullyQualifiedName)
                     {
                         continue;
@@ -183,12 +169,12 @@ internal static class TransformerClassBuilder
             inner: method.Functor.ToTypeSyntax());
         var rawReturnType = method.ReturnType switch
         {
-            ReturnType.Constructed constructed => Compose(
+            ConcreteOrConstructedType.Constructed(var constructed) => Compose(
                 outer: outer.ToGenericNameSyntax(),
-                inner: constructed.ConstructedType.ToTypeSyntax()),
-            ReturnType.Concrete primitive => Compose(
+                inner: constructed.ToTypeSyntax()),
+            ConcreteOrConstructedType.Concrete(var primitive) => Compose(
                 outer: outer.ToGenericNameSyntax(),
-                inner: primitive.Type.ToTypeSyntax()),
+                inner: primitive.ToTypeSyntax()),
             _ => throw new ArgumentOutOfRangeException(nameof(method.ReturnType))
         };
 

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerGenerator.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerGenerator.cs
@@ -17,23 +17,6 @@ namespace FxKit.CompilerServices.CodeGenerators.Transformers;
 public class TransformerGenerator : IIncrementalGenerator
 {
     /// <summary>
-    ///     Fully qualified name for <see cref="GenerateTransformerAttribute" />.
-    /// </summary>
-    public const string GenerateTransformerAttribute =
-        "FxKit.CompilerServices.GenerateTransformerAttribute";
-
-    /// <summary>
-    ///     Fully qualified name for <see cref="ContainsFunctorsAttribute" />.
-    /// </summary>
-    public const string ContainsFunctorsAttribute =
-        "FxKit.CompilerServices.ContainsFunctorsAttribute";
-
-    /// <summary>
-    ///     Fully qualified name for <see cref="FunctorAttribute" />.
-    /// </summary>
-    public const string FunctorAttribute = "FxKit.CompilerServices.FunctorAttribute";
-
-    /// <summary>
     ///     These intrinsic functors will wrap others.
     /// </summary>
     private static readonly IReadOnlyList<string>
@@ -55,7 +38,7 @@ public class TransformerGenerator : IIncrementalGenerator
     {
         // Filter for marked methods and transform them to functor method descriptors.
         var methodsByFunctor = context.SyntaxProvider.ForAttributeWithMetadataName(
-                fullyQualifiedMetadataName: GenerateTransformerAttribute,
+                fullyQualifiedMetadataName: GenerateTransformerAttributeFullyQualifiedName,
                 predicate: static (s, _) => IsMethodSyntaxTargetForGeneration(s),
                 transform: static (ctx, _) =>
                 {
@@ -105,7 +88,7 @@ public class TransformerGenerator : IIncrementalGenerator
         // Find marked type declarations (functors).
         var functorCandidatesFromSyntax =
             context.SyntaxProvider.ForAttributeWithMetadataName(
-                    fullyQualifiedMetadataName: FunctorAttribute,
+                    fullyQualifiedMetadataName: FunctorAttributeFullyQualifiedName,
                     predicate: static (s, _) => IsTypeDeclarationSyntaxTargetForGeneration(s),
                     transform: static (ctx, _) =>
                     {

--- a/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerSet.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Transformers/TransformerSet.cs
@@ -1,0 +1,390 @@
+using FxKit.CompilerServices.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using static FxKit.CompilerServices.CodeGenerators.Transformers.Helpers;
+
+namespace FxKit.CompilerServices.CodeGenerators.Transformers;
+
+/// <summary>
+///     A set of transformer methods to be put into a single generated class.
+/// </summary>
+/// <param name="GeneratedClassName">The class name.</param>
+/// <param name="FunctorNamespace">The namespace the generated class will reside in.</param>
+/// <param name="RequiredNamespaces">Namespaces to include.</param>
+/// <param name="MethodsWithCollidingTypeParameters">
+///     Methods containing colliding type parameters. Needed for error reporting.
+/// </param>
+/// <param name="TransformerMethods">Transformer methods.</param>
+internal sealed record TransformerSet(
+    string GeneratedClassName,
+    string FunctorNamespace,
+    EquatableArray<string> RequiredNamespaces,
+    EquatableArray<FunctorMethodDescriptor> MethodsWithCollidingTypeParameters,
+    EquatableArray<FunctorTransformerMethodDescriptor> TransformerMethods)
+{
+    /// <summary>
+    ///     Creates a set of transformer methods for the given inner functor and
+    ///     all the outer functors
+    /// </summary>
+    /// <param name="allOuterContainers">All known outer functor types.</param>
+    /// <param name="functorName">The name of the functor that appears "on the inside".</param>
+    /// <param name="functorNamespace">The namespace of the inner functor.</param>
+    /// <param name="methods">The methods associated with the inner functor.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A set of transformer methods.</returns>
+    public static TransformerSet Create(
+        IReadOnlyList<Functor> allOuterContainers,
+        string functorName,
+        string functorNamespace,
+        IReadOnlyList<FunctorMethodDescriptor> methods,
+        CancellationToken cancellationToken)
+    {
+        var namespaceList = new HashSet<string>();
+        var methodsWithCollidingTypeParams = new List<FunctorMethodDescriptor>();
+        var transformerMethods = new List<FunctorTransformerMethodDescriptor>(capacity: methods.Count);
+
+        // We don't want to nest one functor within the same functor.
+        var methodGroupFunctorFullyQualifiedName = FullyQualifiedName(
+            functorNamespace,
+            functorName);
+        var outerContainers = allOuterContainers.Where(
+            o => o.FullyQualifiedName != methodGroupFunctorFullyQualifiedName);
+
+        foreach (var outer in outerContainers)
+        {
+            namespaceList.Add(outer.ContainingNamespace);
+            namespaceList.Add(outer.FunctorImplementationNamespace);
+
+            foreach (var method in methods)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                namespaceList.AddRange(method.RequiredNamespaces);
+
+                // Skip "SelectMany" for now since it requires a different implementation.
+                // We can come back to this later.
+                if (method.Name == LinqMonadicBind)
+                {
+                    continue;
+                }
+
+                // Special provisions for `Traverse`/`Sequence`.
+                if (method.Name is Traverse or Sequence)
+                {
+                    // Skip over `Traverse`/`Sequence` methods that would nest two of the same functors.
+                    if (method.ReturnType is ConcreteOrConstructedType.Constructed f &&
+                        f.ConstructedType.FullyQualifiedName == outer.FullyQualifiedName)
+                    {
+                        continue;
+                    }
+
+                    // Generate additional overloads of `Traverse`/`Sequence` that
+                    // accept `IReadOnlyList`, since C# variance sucks.
+                    // For example, doing a `SequenceT` on a `Task<IReadOnlyList<Validation<..>>>` would
+                    // not be allowed because `SequenceT`'s input is `Task<IEnumerable<Validation<..>>>`,
+                    // and C# isn't smart enough to see that yes, an `IReadOnlyList` can in fact be
+                    // a `Task<IEnumerable>`...
+                    if (method.Functor.FullyQualifiedName == IEnumerableFullyQualifiedName)
+                    {
+                        // Skip generating `IReadOnlyList<IReadOnlyList<..>>`.
+                        if (outer.FullyQualifiedName == IReadOnlyListFullyQualifiedName)
+                        {
+                            continue;
+                        }
+
+                        // Used to synthesize an `IReadOnlyList` overload for methods where the functor (source) is
+                        // `IEnumerable`. This is because C# does not allow a `Task<IReadOnlyList>` where
+                        // a `Task<IEnumerable>` is expected.
+                        var synthesized = method.ReplaceFunctor(
+                            method.Functor.ReplaceReference(
+                                name: "IReadOnlyList",
+                                containingNamespace: "System.Collections.Generic"));
+                        transformerMethods.Add(
+                            FunctorTransformerMethodDescriptor.From(
+                                transformerMethodName: ComputeTransformerName(synthesized.Name),
+                                outer: outer,
+                                originalMethod: synthesized,
+                                typeParameterCollisionDetected: out _));
+                    }
+                }
+
+                var transformerMethod = FunctorTransformerMethodDescriptor.From(
+                    transformerMethodName: ComputeTransformerName(method.Name),
+                    outer: outer,
+                    originalMethod: method,
+                    typeParameterCollisionDetected: out var typeParameterCollisionDetected);
+                transformerMethods.Add(transformerMethod);
+
+                if (typeParameterCollisionDetected)
+                {
+                    methodsWithCollidingTypeParams.Add(method);
+                }
+
+                // For LINQ's Where, we want to generate a `WhereT` transformer to be
+                // used with method chaining, and a `Where` transformer with the same signature
+                // as `WhereT` to be used by the LINQ Query Syntax.
+                if (method.Name == LinqFilterName)
+                {
+                    transformerMethods.Add(
+                        FunctorTransformerMethodDescriptor.From(
+                            transformerMethodName: method.Name,
+                            outer: outer,
+                            originalMethod: method,
+                            typeParameterCollisionDetected: out _));
+                }
+            }
+        }
+
+        namespaceList.Remove(functorNamespace);
+
+        return new TransformerSet(
+            GeneratedClassName: $"{functorName}T",
+            FunctorNamespace: functorNamespace,
+            RequiredNamespaces: namespaceList.OrderBy(static x => x).ToEquatableArray(),
+            MethodsWithCollidingTypeParameters: methodsWithCollidingTypeParams.ToEquatableArray(),
+            TransformerMethods: transformerMethods.ToEquatableArray());
+    }
+
+    /// <summary>
+    ///     Computes the name for the transformer method.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    private static string ComputeTransformerName(string name) => name switch
+    {
+        "Select" => "Select",
+        _        => $"{name}T"
+    };
+}
+
+/// <summary>
+///     Descriptor for a transformer method.
+/// </summary>
+/// <param name="TransformerMethodName">The transformer method's name.</param>
+/// <param name="InnerMethodName">The name of the method being called by the transformer method.</param>
+/// <param name="OuterFunctorName">The name of the outer functor for this transformer method.</param>
+/// <param name="InnerFunctorName">The name of the inner functor for this transformer method.</param>
+/// <param name="TypeParameterNames">Type parameters needed.</param>
+/// <param name="TypeParameterConstraints">Constraints for type parameters.</param>
+/// <param name="StackedSource">The stacked source (<c>this</c>) parameter.</param>
+/// <param name="Parameters">Parameters for the method (not including `this`).</param>
+/// <param name="ReturnType">The transformer method's return type.</param>
+/// <param name="RequiresFlattening">
+///     Whether the implementation of the transformer needs to
+///     flatten the result.
+/// </param>
+internal sealed record FunctorTransformerMethodDescriptor(
+    string TransformerMethodName,
+    string InnerMethodName,
+    string OuterFunctorName,
+    string InnerFunctorName,
+    EquatableArray<string> TypeParameterNames,
+    EquatableArray<TypeParameterConstraints> TypeParameterConstraints,
+    ConstructedFunctor StackedSource,
+    EquatableArray<FunctorMethodParameter> Parameters,
+    ConstructedFunctor ReturnType,
+    bool RequiresFlattening)
+{
+    /// <summary>
+    ///     Creates a transformer method descriptor from the given
+    ///     outer functor and original method.
+    /// </summary>
+    /// <param name="transformerMethodName">The name of the returned transformer method.</param>
+    /// <param name="outer">The outer functor.</param>
+    /// <param name="originalMethod">The original method having a transformer generated for it.</param>
+    /// <param name="typeParameterCollisionDetected">
+    ///     Will be set to <c>true</c> if a type parameter collision was detected.
+    /// </param>
+    /// <returns>The transformer method descriptor.</returns>
+    public static FunctorTransformerMethodDescriptor From(
+        string transformerMethodName,
+        Functor outer,
+        FunctorMethodDescriptor originalMethod,
+        out bool typeParameterCollisionDetected)
+    {
+        // Create a stacked source type.
+        // For example, if the outer functor is `Task<T>`, and
+        // the original method's functor (source parameter) is `Option<T>`,
+        // then our stacked source becomes `Task<Option<T>>`.
+        var stackedSource = ConstructedFunctor.From(
+            outer: outer,
+            inner: ConcreteOrConstructedType.Constructed.Of(originalMethod.Functor));
+
+        // Similarly, create the return type.
+        var rawReturnType = ConstructedFunctor.From(
+            outer: outer,
+            inner: originalMethod.ReturnType);
+
+        // Check if we need to flatten the return type.
+        // This would be the case when the return type is `Task<Task<Result<TOk, TErr>>>`, but what we
+        // want is `Task<Result<TOk, TErr>>`.
+        var returnType = MaybeFlattenReturnType(rawReturnType, out var requiresFlattening);
+
+        // Compute the type parameters needed for the transformer method.
+        var typeParameters = ComputeTypeParameters(
+            outer: outer,
+            method: originalMethod,
+            typeParameterCollisionDetected: out typeParameterCollisionDetected);
+        var typeParameterConstraints = ComputeTypeParameterConstraints(
+            outer: outer,
+            method: originalMethod);
+
+        return new FunctorTransformerMethodDescriptor(
+            TransformerMethodName: transformerMethodName,
+            InnerMethodName: originalMethod.Name,
+            OuterFunctorName: outer.Name,
+            InnerFunctorName: originalMethod.Functor.Name,
+            TypeParameterNames: typeParameters,
+            TypeParameterConstraints: typeParameterConstraints,
+            StackedSource: stackedSource,
+            Parameters: originalMethod.Parameters,
+            ReturnType: returnType,
+            RequiresFlattening: requiresFlattening);
+    }
+
+    /// <summary>
+    ///     Computes the required type parameters for the transformer given the method in question
+    ///     and the functor type.
+    /// </summary>
+    /// <param name="outer">The outer functor type for the generated transformer.</param>
+    /// <param name="method">The method being wrapped in a transformer.</param>
+    /// <param name="typeParameterCollisionDetected">
+    ///     Will be set according to whether a type parameter name collision was detected.
+    /// </param>
+    /// <returns>The type parameters in the order they should appear.</returns>
+    private static EquatableArray<string> ComputeTypeParameters(
+        Functor outer,
+        FunctorMethodDescriptor method,
+        out bool typeParameterCollisionDetected)
+    {
+        // Consider a method of the form:
+        //
+        //  Result<TNewOk, TErr> Map<TOk, TErr, TNewOk>(...)
+        //
+        // If we're creating a Validation of Result transformer and use the
+        // original method's type parameters as well as Validation's type
+        // parameters as the transformer's type parameters, we'll end up
+        // with an unused parameter:
+        //
+        //  Validation<Result<TNewOk, TErr>, TInvalid> MapT<TOk, TErr, TNewOk, TValid, TInvalid>(...).
+        //
+        // In this case, it was `TValid`. It's not used because `Result` gets used in its place.
+        // For that reason, we want to remove the type parameter in the spot where we're
+        // placing the composed type.
+        //
+        // Additionally, we'll need to detect whether the composition of the functors
+        // will result in a type parameter collision.
+        var typeParameters = method.TypeParameters
+            .Concat(outer.TypeParameters.Skip(1))
+            .ToEquatableArray();
+
+        typeParameterCollisionDetected = typeParameters.Distinct().Count() != typeParameters.Length;
+        return typeParameters;
+    }
+
+    /// <summary>
+    ///     Computes the constraints for the transformer method's type parameters.
+    /// </summary>
+    /// <param name="outer">The outer functor type for the generated transformer.</param>
+    /// <param name="method">The method being wrapped in a transformer.</param>
+    /// <returns>The combined constraints.</returns>
+    private static EquatableArray<TypeParameterConstraints> ComputeTypeParameterConstraints(
+        Functor outer,
+        FunctorMethodDescriptor method)
+    {
+        // When composing `Result<TOk, TErr>` within `Validation<TValid, TInvalid>`, the
+        // `TValid` parameter will no longer be needed (because `Result<TOk, TErr>` is `TValid`).
+        // Therefore, we don't want to copy its generic constraint over to the new method either.
+        // See `ComputeTypeParameters` for a more elaborate explanation of this.
+        var parameterApplied = outer.TypeParameters[0];
+
+        var clausesFromFunctorDefinition = outer.ConstraintClauses
+            .Where(c => c.Name != parameterApplied);
+
+        return method.ConstraintClauses.Concat(clausesFromFunctorDefinition).ToEquatableArray();
+    }
+
+    /// <summary>
+    ///     Flattens the given return type if needed.
+    /// </summary>
+    /// <param name="returnType">The return type to flatten, if needed.</param>
+    /// <param name="requiresFlattening">Will be set to <c>true</c> if the return type was flattened.</param>
+    /// <returns></returns>
+    private static ConstructedFunctor MaybeFlattenReturnType(
+        ConstructedFunctor returnType,
+        out bool requiresFlattening)
+    {
+        // Bail if the outer functor isn't `Task`.
+        if (returnType.FunctorName is not CSharpTaskMonad)
+        {
+            requiresFlattening = false;
+            return returnType;
+        }
+
+        // Bail if the first type argument to the return type isn't `Task`
+        if (returnType.TypeArguments[0] is not
+            ConcreteOrConstructedType.Constructed({ Name: CSharpTaskMonad } firstTypeArgument))
+        {
+            requiresFlattening = false;
+            return returnType;
+        }
+
+        requiresFlattening = true;
+        return new ConstructedFunctor(
+            FunctorName: CSharpTaskMonad,
+            TypeArguments: new []
+            {
+                firstTypeArgument.TypeArguments[0]
+            }.ToEquatableArray());
+    }
+}
+
+/// <summary>
+///     A functor that has been constructed with type arguments.
+/// </summary>
+/// <param name="FunctorName"></param>
+/// <param name="TypeArguments"></param>
+internal sealed record ConstructedFunctor(
+    string FunctorName,
+    EquatableArray<ConcreteOrConstructedType> TypeArguments)
+{
+    /// <summary>
+    ///     Creates a <see cref="GenericNameSyntax"/> from this constructed functor.
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public GenericNameSyntax ToGenericNameSyntax()
+    {
+        var args = SeparatedList(
+            TypeArguments.Select(
+                static t => t switch
+                {
+                    ConcreteOrConstructedType.Concrete(var type) =>
+                        type.ToTypeSyntax(),
+                    ConcreteOrConstructedType.Constructed(var type) =>
+                        type.ToTypeSyntax(),
+                    _ => throw new ArgumentOutOfRangeException(nameof(t))
+                }));
+
+        return GenericName(FunctorName).WithTypeArgumentList(TypeArgumentList(args));
+    }
+
+    /// <summary>
+    ///     Creates a <see cref="ConstructedFunctor"/> by constructing a concrete functor type
+    ///     using the given <paramref name="inner"/> type.
+    ///
+    ///     For example, given an outer functor <c>Result&lt;T, E&gt;</c> and inner type <c>Option&lt;T&gt;</c>,
+    ///     returns <c>Result&lt;Option&lt;T&gt;, E&gt;</c>.
+    /// </summary>
+    public static ConstructedFunctor From(Functor outer, ConcreteOrConstructedType inner)
+    {
+        var typeArgs = outer.TypeParameters.Skip(1)
+            // We know we can use a concrete type for the type argument because they
+            // cannot be generic themselves (otherwise, we'd have HKTs, and we wouldn't need
+            // this generator at all).
+            .Select(static t => ConcreteOrConstructedType.Concrete.Of(new ConcreteType(Type: t)))
+            .Prepend(inner)
+            .ToEquatableArray();
+
+        return new ConstructedFunctor(FunctorName: outer.Name, TypeArguments: typeArgs);
+    }
+}

--- a/src/FxKit.CompilerServices/Utilities/EquatableMetadataReference.cs
+++ b/src/FxKit.CompilerServices/Utilities/EquatableMetadataReference.cs
@@ -1,0 +1,61 @@
+using Microsoft.CodeAnalysis;
+
+namespace FxKit.CompilerServices.Utilities;
+
+/// <summary>
+///     An equatable <see cref="MetadataReference"/> that weakly references a <see cref="Compilation"/>.
+///     Requires that retrieving the compilation is performed immediately following a
+///     change to the <see cref="MetadataReference"/> in order to guarantee
+///     the <see cref="Compilation"/> has not yet been garbage-collected.
+/// </summary>
+public sealed class EquatableMetadataReference(
+    MetadataReference reference,
+    Compilation compilation)
+    : IEquatable<EquatableMetadataReference>
+{
+    /// <summary>
+    ///     Weakly references the compilation. Compilations are huge and we don't want to inadvertently
+    ///     cache them.
+    /// </summary>
+    private readonly WeakReference<Compilation> _compilationReference = new(compilation);
+
+    /// <summary>
+    ///     Gets the weakly-referenced compilation.
+    /// </summary>
+    /// <exception cref="NullReferenceException">The compilation was garbage-collected.</exception>
+    public Compilation Compilation
+    {
+        get
+        {
+            if (_compilationReference.TryGetTarget(out var compilation))
+            {
+                return compilation;
+            }
+
+            throw new NullReferenceException("The compilation was garbage-collected.");
+        }
+    }
+
+    /// <summary>
+    ///     The metadata reference.
+    /// </summary>
+    public MetadataReference Reference { get; } = reference;
+
+    /// <inheritdoc />
+    public bool Equals(EquatableMetadataReference? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        // Only PE references can be checked for equality; others are assumed not equal.
+        if (this.Reference is not PortableExecutableReference left ||
+            other.Reference is not PortableExecutableReference right)
+        {
+            return false;
+        }
+
+        return left.GetMetadataId() == right.GetMetadataId();
+    }
+}

--- a/src/FxKit/Option/Option.Do.cs
+++ b/src/FxKit/Option/Option.Do.cs
@@ -26,6 +26,7 @@ public partial class Option
     /// <summary>
     /// Asynchronously runs <see cref="callback" /> if the <paramref name="source" /> is Some.
     /// </summary>
+    [GenerateTransformer]
     public static async Task<Option<T>> DoAsync<T>(this Option<T> source, Func<T, Task> callback)
         where T : notnull
     {


### PR DESCRIPTION
This PR adds another incremental caching layer for transformer sets, reducing the amount of syntax node gymnastics we need to do in the transform step.

This paves the way for getting rid of the `SyntaxFactory`-based generation in favor of manually constructing the syntax [as is recommended by the Roslyn team](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.cookbook.md#use-an-indented-text-writer-not-syntaxnodes-for-generation).