### PR TITLE
perf: Optimize ListExtensions, Option and Result

### DIFF
--- a/src/FxKit/Extensions/ListExtensions.cs
+++ b/src/FxKit/Extensions/ListExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using FxKit.CompilerServices;
 
 namespace FxKit.Extensions;
@@ -22,8 +23,15 @@ public static class ListExtensions
     [GenerateTransformer]
     public static IReadOnlyList<R> Map<T, R>(this IReadOnlyList<T> source, Func<T, R> selector)
     {
-        var result = new List<R>(source.Count);
-        result.AddRange(source.Select(item => selector(item)));
+        var result = new List<R>();
+
+        CollectionsMarshal.SetCount(result, source.Count);
+        var span = CollectionsMarshal.AsSpan(result);
+        for (var i = 0; i < source.Count; i++)
+        {
+            span[i] = selector(source[i]);
+        }
+
         return result;
     }
 

--- a/src/FxKit/Option/Option.Do.cs
+++ b/src/FxKit/Option/Option.Do.cs
@@ -22,4 +22,18 @@ public partial class Option
 
         return source;
     }
+
+    /// <summary>
+    /// Asynchronously runs <see cref="callback" /> if the <paramref name="source" /> is Some.
+    /// </summary>
+    public static async Task<Option<T>> DoAsync<T>(this Option<T> source, Func<T, Task> callback)
+        where T : notnull
+    {
+        if (source.TryGet(out var value))
+        {
+            await callback(value).ConfigureAwait(false);
+        }
+
+        return source;
+    }
 }

--- a/src/FxKit/Option/Option.EscapeHatch.cs
+++ b/src/FxKit/Option/Option.EscapeHatch.cs
@@ -69,7 +69,7 @@ public static partial class Option
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async Task<T?> ToNullableAsync<T>(this Task<Option<T>> source)
         where T : class =>
-        (await source).TryGet(out var result) ? result : null;
+        (await source.ConfigureAwait(false)).TryGet(out var result) ? result : null;
 
     /// <summary>
     ///     Like <see cref="ToNullable{T}" /> but for tasks.
@@ -81,7 +81,7 @@ public static partial class Option
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static async ValueTask<T?> ToNullableAsync<T>(this ValueTask<Option<T>> source)
         where T : class =>
-        (await source).TryGet(out var result) ? result : null;
+        (await source.ConfigureAwait(false)).TryGet(out var result) ? result : null;
 
     /// <summary>
     ///     Unwraps the option, returning the <typeparamref name="T" />> held within if in a Some state.
@@ -99,11 +99,10 @@ public static partial class Option
         this Option<T> source,
         string? exceptionMessage = null)
         where T : notnull =>
-        source.Match(
-            ok => ok,
-            () =>
-                throw new InvalidOperationException(
-                    exceptionMessage ?? "The option did not contain a value."));
+        source.TryGet(out var value)
+            ? value
+            : throw new InvalidOperationException(
+                exceptionMessage ?? "The option did not contain a value.");
 
     /// <summary>
     ///     Unwraps the option, returning the <typeparamref name="T" />> held within if in a Some state.
@@ -118,7 +117,7 @@ public static partial class Option
     public static T UnwrapOr<T>(
         this Option<T> source,
         T fallback)
-        where T : notnull => source.Match(ok => ok, () => fallback);
+        where T : notnull => source.TryGet(out var value) ? value : fallback;
 
     /// <summary>
     ///     Unwraps the option, returning the <typeparamref name="T" />> held within if in a Some state.
@@ -133,7 +132,7 @@ public static partial class Option
     public static T UnwrapOrElse<T>(
         this Option<T> source,
         Func<T> fallback)
-        where T : notnull => source.Match(ok => ok, fallback);
+        where T : notnull => source.TryGet(out var value) ? value : fallback();
 
     /// <summary>
     /// Returns the values from a sequence of <see cref="Option{T}"/> where the option has a value.

--- a/src/FxKit/Option/Option.Filtering.cs
+++ b/src/FxKit/Option/Option.Filtering.cs
@@ -21,5 +21,7 @@ public static partial class Option
         this Option<T> source,
         Func<T, bool> predicate)
         where T : notnull =>
-        FlatMap(source, v => predicate(v) ? Some(v) : Option<T>.None);
+        source.TryGet(out var value) && predicate(value)
+            ? source
+            : Option<T>.None;
 }

--- a/src/FxKit/Option/Option.Monad.cs
+++ b/src/FxKit/Option/Option.Monad.cs
@@ -22,9 +22,9 @@ public static partial class Option
         Func<T, Option<U>> selector)
         where T : notnull
         where U : notnull =>
-        source.Match(
-            Some: v => selector(v),
-            None: () => Option<U>.None);
+        source.TryGet(out var value)
+            ? selector(value)
+            : Option<U>.None;
 
     /// <summary>
     ///     Asynchronously maps the source's Some value to another Option that is unwrapped.
@@ -46,9 +46,9 @@ public static partial class Option
         Func<T, Task<Option<U>>> selector)
         where T : notnull
         where U : notnull =>
-        source.Match(
-            Some: selector,
-            None: () => Option<U>.None.ToTask());
+        source.TryGet(out var value)
+            ? selector(value)
+            : Task.FromResult(Option<U>.None);
 
     #region LINQ
 
@@ -83,9 +83,9 @@ public static partial class Option
         where T : notnull
         where U : notnull
         where UU : notnull =>
-        source.Match(
-            Some: b => bind(b).Select(v => selector(b, v)),
-            None: () => Option<UU>.None);
+        source.TryGet(out var srcValue) && bind(srcValue).TryGet(out var bindValue)
+            ? Option<UU>.Some(selector(srcValue, bindValue))
+            : Option<UU>.None;
 
     #endregion
 }

--- a/src/FxKit/Option/Option.NaturalTransformations.cs
+++ b/src/FxKit/Option/Option.NaturalTransformations.cs
@@ -66,9 +66,9 @@ public static partial class Option
         Func<E> selector)
         where T : notnull
         where E : notnull =>
-        source.Match(
-            Some: Validation<T, E>.Valid,
-            None: () => Validation<T, E>.Invalid(selector()));
+        source.TryGet(out var value)
+            ? Validation<T, E>.Valid(value)
+            : Validation<T, E>.Invalid(selector());
 
     /// <summary>
     ///     Maps the <see cref="Option{T}" /> to a <see cref="Validation{T,E}" />.
@@ -82,7 +82,10 @@ public static partial class Option
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [GenerateTransformer]
     public static Validation<T, E> ValidOr<T, E>(this Option<T> source, E invalidValue)
-        where E : notnull where T : notnull => source.ValidOrElse(() => invalidValue);
+        where E : notnull where T : notnull =>
+        source.TryGet(out var value)
+            ? Validation<T, E>.Valid(value)
+            : Validation<T, E>.Invalid(invalidValue);
 
     /// <summary>
     ///     Converts the <see cref="Option{T}" /> into a <see cref="Result{T,E}" />.
@@ -91,6 +94,8 @@ public static partial class Option
     /// <returns></returns>
     [GenerateTransformer]
     public static Result<T, Option.None> ToResult<T>(this Option<T> source)
-        where T : notnull
-        => source.OkOrElse(() => new Option.None());
+        where T : notnull =>
+        source.TryGet(out var value)
+            ? Result<T, None>.Ok(value)
+            : Result<T, None>.Err(new Option.None());
 }

--- a/src/FxKit/Result/Result.Do.cs
+++ b/src/FxKit/Result/Result.Do.cs
@@ -76,7 +76,7 @@ public static partial class Result
     {
         if (source.TryGet(out var ok, out _))
         {
-            await callback(ok);
+            await callback(ok).ConfigureAwait(false);
         }
 
         return source;
@@ -102,7 +102,7 @@ public static partial class Result
     {
         if (!source.TryGet(out _, out var err))
         {
-            await callback(err);
+            await callback(err).ConfigureAwait(false);
         }
 
         return source;

--- a/src/FxKit/Result/Result.EscapeHatch.cs
+++ b/src/FxKit/Result/Result.EscapeHatch.cs
@@ -20,7 +20,7 @@ public static partial class Result
     public static T UnwrapEither<T>(
         this Result<T, T> source)
         where T : notnull =>
-        source.Match(ok => ok, err => err);
+        source.TryGet(out var ok, out var err) ? ok : err;
 
     /// <summary>
     ///     Unwraps the result and returns the Ok value, or throws an exception otherwise.
@@ -39,10 +39,10 @@ public static partial class Result
         string? exceptionMessage = "")
         where TOk : notnull
         where TErr : notnull
-        => source.Match(
-            ok => ok,
-            err => throw new InvalidOperationException(
-                exceptionMessage ?? err.ToString() ?? "The result was in an Error state."));
+        => source.TryGet(out var ok, out var err)
+            ? ok
+            : throw new InvalidOperationException(
+                exceptionMessage ?? err.ToString() ?? "The result was in an Error state.");
 
     /// <summary>
     ///     Unwraps the result, returning the <typeparamref name="TOk" />> held within if in a Ok state.
@@ -58,7 +58,7 @@ public static partial class Result
         this Result<TOk, TErr> source,
         TOk fallback)
         where TOk : notnull
-        where TErr : notnull => source.Match(ok => ok, _ => fallback);
+        where TErr : notnull => source.TryGet(out var ok, out _) ? ok : fallback;
 
     /// <summary>
     ///     Unwraps the result, returning the <typeparamref name="TOk" />> held within if in a Ok state.
@@ -75,7 +75,7 @@ public static partial class Result
         Func<TErr, Exception> mapException)
         where TOk : notnull
         where TErr : notnull
-        => source.Match(ok => ok, err => throw mapException(err));
+        => source.TryGet(out var ok, out var err) ? ok : throw mapException(err);
 
     /// <summary>
     ///     Unwraps the result, returning the <typeparamref name="TOk" /> held within if in an Ok state.
@@ -89,7 +89,7 @@ public static partial class Result
         Func<TOk> fallbackFunction)
         where TOk : notnull
         where TErr : notnull
-        => source.Match(Ok: Identity, Err: _ => fallbackFunction());
+        => source.TryGet(out var ok, out _) ? ok : fallbackFunction();
 
     /// <summary>
     ///     Unwraps the result, expecting it to be in an error state.
@@ -106,10 +106,10 @@ public static partial class Result
         string? exceptionMessage = null)
         where TOk : notnull
         where TErr : notnull
-        => source.Match(
-            Ok: ok => throw new InvalidOperationException(
-                exceptionMessage ?? ok.ToString() ?? "The result was in an Ok state."),
-            Err: Identity);
+        => source.TryGet(out var ok, out var err)
+            ? throw new InvalidOperationException(
+                exceptionMessage ?? ok.ToString() ?? "The result was in an Ok state.")
+            : err;
 
     /// <summary>
     ///     Matches on the result, calling either <paramref name="Ok" /> or <paramref name="Err" />

--- a/src/FxKit/Result/Result.NaturalTransformations.cs
+++ b/src/FxKit/Result/Result.NaturalTransformations.cs
@@ -36,7 +36,7 @@ public static partial class Result
     public static Option<T> ToOption<T, E>(this Result<T, E> source)
         where T : notnull
         where E : notnull =>
-        source.Match(
-            Some,
-            _ => None);
+        source.TryGet(out var ok, out _)
+            ? Some(ok)
+            : None;
 }

--- a/src/FxKit/Result/TaskResult.Functor.cs
+++ b/src/FxKit/Result/TaskResult.Functor.cs
@@ -7,13 +7,15 @@ public static partial class Result
     /// <summary>
     ///     LINQ Extension Method for `MapAsyncT`.
     /// </summary>
-    public static Task<Result<TNewOk, TErr>> Select<TOk, TNewOk, TErr>(
+    public static async Task<Result<TNewOk, TErr>> Select<TOk, TNewOk, TErr>(
         this Task<Result<TOk, TErr>> source,
         Func<TOk, Task<TNewOk>> selector) // Notice: Maps to Task<U>
         where TOk : notnull
         where TNewOk : notnull
         where TErr : notnull
-        => source.MapAsyncT(selector);
+        => (await source.ConfigureAwait(false)).TryGet(out var ok, out var err)
+            ? await selector(ok).ConfigureAwait(false)
+            : Result<TNewOk, TErr>.Err(err);
 
     #endregion
 }


### PR DESCRIPTION
- Fast list creation for `Map` extension for `IReadOnlyList<T>`
- Optimize `Option` and `Result` operations avoiding allocation
- Make `Option` implement `IStructuralEquatable`