### PR TITLE
Prevent double-printing of `?` token

### DIFF
--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/Unions/UnionGeneratorTests.SupportsNullableAnnotationsOnGenerics.verified.txt
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/Unions/UnionGeneratorTests.SupportsNullableAnnotationsOnGenerics.verified.txt
@@ -9,9 +9,9 @@ using System.Runtime.CompilerServices;
 
 namespace Super.Duper.Unions;
 
-public abstract partial record Foo
+public abstract partial record TerribleOption<T>
 {
-    public sealed partial record Probably : Foo
+    public sealed partial record Probably : TerribleOption<T>
     {
         /// <summary>
         ///     The same as "new Probably" but the return type is that of the base type.
@@ -19,20 +19,18 @@ public abstract partial record Foo
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ExcludeFromCodeCoverage]
         [DebuggerHidden]
-        public static Foo Of(
-            int? Number,
-            string? Text) =>
+        public static TerribleOption<T> Of(
+            T? Value) =>
             new Probably(
-                Number,
-                Text);
+                Value);
 
         /// <summary>
         ///     A Func variant for 'Of'
         /// </summary>
-        public static readonly Func<int?, string?, Foo> λ = Of;
+        public static readonly Func<T?, TerribleOption<T>> λ = Of;
     }
 
-    public sealed partial record None : Foo
+    public sealed partial record None : TerribleOption<T>
     {
         /// <summary>
         ///     The same as "new None" but the return type is that of the base type.
@@ -40,13 +38,13 @@ public abstract partial record Foo
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ExcludeFromCodeCoverage]
         [DebuggerHidden]
-        public static Foo Of() =>
+        public static TerribleOption<T> Of() =>
             new None();
 
         /// <summary>
         ///     A Func variant for 'Of'
         /// </summary>
-        public static readonly Func<Foo> λ = Of;
+        public static readonly Func<TerribleOption<T>> λ = Of;
     }
 
     /// <summary>
@@ -56,8 +54,8 @@ public abstract partial record Foo
         Func<Probably, TResult> Probably,
         Func<None, TResult> None) => this switch
     {
-        Foo.Probably x => Probably(x),
-        Foo.None x => None(x),
-        _ => throw new ArgumentOutOfRangeException(message: $"The type '{this.GetType()}' is not a known variant of Foo", innerException: null)
+        TerribleOption<T>.Probably x => Probably(x),
+        TerribleOption<T>.None x => None(x),
+        _ => throw new ArgumentOutOfRangeException(message: $"The type '{this.GetType()}' is not a known variant of TerribleOption", innerException: null)
     };
 }

--- a/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/Unions/UnionGeneratorTests.cs
+++ b/src/FxKit.CompilerServices.Tests/UnitTests/CodeGenerators/Unions/UnionGeneratorTests.cs
@@ -92,6 +92,26 @@ public class UnionGeneratorTests
             namespace Super.Duper.Unions;
 
             [Union]
+            public partial record Foo
+            {
+                partial record Probably(int? Number, string? Text);
+                partial record None;
+            }
+            """);
+        await output.VerifyGeneratedCode();
+    }
+
+    [Test]
+    public async Task SupportsNullableAnnotationsOnGenerics()
+    {
+        var output = Generate(
+            """
+            using System.Collections.Generic;
+            using FxKit.CompilerServices;
+
+            namespace Super.Duper.Unions;
+
+            [Union]
             public partial record TerribleOption<T>
             {
                 partial record Probably(T? Value);

--- a/src/FxKit.CompilerServices/CodeGenerators/Lambdas/LambdaSyntaxBuilder.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Lambdas/LambdaSyntaxBuilder.cs
@@ -59,7 +59,7 @@ internal static class LambdaSyntaxBuilder
                 foreach (var param in descriptor.Parameters)
                 {
                     writer.Write(param.FullyQualifiedTypeName);
-                    if (param.HasNullableAnnotation)
+                    if (param.RequiresAdditionalNullableAnnotation)
                     {
                         writer.Write("?");
                     }

--- a/src/FxKit.CompilerServices/CodeGenerators/Unions/UnionSyntaxBuilder.cs
+++ b/src/FxKit.CompilerServices/CodeGenerators/Unions/UnionSyntaxBuilder.cs
@@ -104,7 +104,7 @@ internal static class UnionSyntaxBuilder
             sb.WriteLine();
             var param = member.Parameters[i];
             sb.Write(param.FullyQualifiedTypeName);
-            if (param.HasNullableAnnotation)
+            if (param.RequiresAdditionalNullableAnnotation)
             {
                 sb.Write("?");
             }

--- a/src/FxKit.CompilerServices/Models/BasicParameter.cs
+++ b/src/FxKit.CompilerServices/Models/BasicParameter.cs
@@ -11,21 +11,35 @@ namespace FxKit.CompilerServices.Models;
 /// <param name="Identifier">
 ///     The name of the parameter.
 /// </param>
-/// <param name="HasNullableAnnotation">
-///     Whether the parameter has a nullable annotation.
+/// <param name="RequiresAdditionalNullableAnnotation">
+///     Whether the parameter requires printing an additional `?`.
+///     This may be false in case the <see cref="FullyQualifiedTypeName"/> already includes
+///     the `?`, such as for value types.
 /// </param>
 internal sealed record BasicParameter(
     string FullyQualifiedTypeName,
     string Identifier,
-    bool HasNullableAnnotation)
+    bool RequiresAdditionalNullableAnnotation)
 {
     /// <summary>
     ///     Converts a <see cref="IParameterSymbol" /> to a <see cref="BasicParameter" />.
     /// </summary>
     /// <param name="symbol"></param>
     /// <returns></returns>
-    internal static BasicParameter FromSymbol(IParameterSymbol symbol) => new(
-        FullyQualifiedTypeName: symbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-        Identifier: symbol.Name,
-        HasNullableAnnotation: symbol.NullableAnnotation is NullableAnnotation.Annotated);
+    internal static BasicParameter FromSymbol(IParameterSymbol symbol)
+    {
+        var fullyQualifiedTypeName =
+            symbol.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        // If the type is a nullable value type, the type name will include a `?` as well, in which
+        // case we won't need to write an additional token when printing.
+        var requiresAdditionalNullableAnnotation =
+            symbol.NullableAnnotation is NullableAnnotation.Annotated &&
+            fullyQualifiedTypeName[^1] != '?';
+
+        return new BasicParameter(
+            FullyQualifiedTypeName: fullyQualifiedTypeName,
+            Identifier: symbol.Name,
+            RequiresAdditionalNullableAnnotation: requiresAdditionalNullableAnnotation);
+    }
 }

--- a/src/FxKit.CompilerServices/Utilities/IndentedTextWriterExtensions.cs
+++ b/src/FxKit.CompilerServices/Utilities/IndentedTextWriterExtensions.cs
@@ -49,7 +49,7 @@ internal static class IndentedTextWriterExtensions
         {
             var parameter = parameters[i];
             writer.Write(parameter.FullyQualifiedTypeName);
-            if (parameter.HasNullableAnnotation)
+            if (parameter.RequiresAdditionalNullableAnnotation)
             {
                 writer.Write("?");
             }


### PR DESCRIPTION
When using nullable value types, the fully qualified type name includes the `?` token already, so we don't need to print it.