### PR TITLE
feat: Add `TryAggregate` for `Option` and `Result`

### DIFF
--- a/docs/core/option.md
+++ b/docs/core/option.md
@@ -241,6 +241,25 @@ Option<IReadOnlyList<int>> sequenced =
     list.Sequence();
 ```
 
+### TryAggregate
+
+Use `TryAggregate` to attempt an aggregation of a sequence with a custom function that can short-circuit if any step fails.
+
+```csharp
+var numbers = new[] { 1, 2, 3, 4 };
+var result = numbers.TryAggregate(
+    seed: 0,
+    func: (acc, item) => item > 0 ? Some(acc + item) : None
+);
+// Some(10)
+
+var invalidResult = numbers.TryAggregate(
+    seed: 0,
+    func: (acc, item) => item < 2 ? Some(acc + item) : None
+);
+// None
+```
+
 ## Prelude
 
 The `Prelude` class provides the following functions for `Option`:

--- a/docs/core/result.md
+++ b/docs/core/result.md
@@ -233,6 +233,21 @@ Result<IReadOnlyList<int>, string> sequenced =
     list.Sequence();
 ```
 
+### TryAggregate
+
+Use `TryAggregate` to attempt an aggregation of a sequence with a custom function that can short-circuit if any step
+fails, returning either the final accumulated value or an error.
+
+```csharp
+IReadOnlyList<int> numbers = [1, 2, 3, 4];
+Result<int, string> sumResult = numbers.TryAggregate(
+    seed: 0,
+    func: (acc, item) => item > 0
+        ? Ok<int, string>(acc + item)
+        : Err<int, string>("Negative number encountered")
+);
+```
+
 ## Prelude
 
 The `Prelude` class provides the following functions for `Result`:

--- a/src/FxKit.Tests/UnitTests/Option/Option.TraverseTests.cs
+++ b/src/FxKit.Tests/UnitTests/Option/Option.TraverseTests.cs
@@ -76,4 +76,37 @@ public class OptionTraverseTests
         Some(Err<int, string>("error")).Sequence().Should().BeErr("error");
         Option<Result<int, string>>.None.Sequence().Should().BeOk(None);
     }
+
+    [Test]
+    public void TryAggregate_ShouldAggregateValuesCorrectly()
+    {
+        ListOf.Many(1, 2, 3, 4)
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) => Some(acc + item))
+            .Should()
+            .BeSome(10);
+    }
+
+    [Test]
+    public void TryAggregate_ShouldReturnError_WhenConditionFails()
+    {
+        ListOf.Many(1, -1, 3)
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) => item >= 0 ? Some(acc + item) : None)
+            .Should()
+            .BeNone();
+    }
+
+    [Test]
+    public void TryAggregate_ShouldHandleEmptySequence()
+    {
+        Array.Empty<int>()
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) => Some(acc + item))
+            .Should()
+            .BeSome(0);
+    }
 }

--- a/src/FxKit.Tests/UnitTests/Result/Result.TraverseTests.cs
+++ b/src/FxKit.Tests/UnitTests/Result/Result.TraverseTests.cs
@@ -45,4 +45,40 @@ public class ResultTraverseTests
         Result<int, string> Ok(int x) => x;
         Result<int, string> Err(string x) => x;
     }
+
+    [Test]
+    public void TryAggregate_ShouldAggregateValuesCorrectly()
+    {
+        ListOf.Many(1, 2, 3, 4)
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) => Ok<int, string>(acc + item))
+            .Should()
+            .BeOk(10);
+    }
+
+    [Test]
+    public void TryAggregate_ShouldReturnError_WhenConditionFails()
+    {
+        ListOf.Many(1, -1, 3)
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) =>
+                    item >= 0
+                        ? Ok<int, string>(acc + item)
+                        : Err<int, string>("Negative number encountered"))
+            .Should()
+            .BeErr("Negative number encountered");
+    }
+
+    [Test]
+    public void TryAggregate_ShouldHandleEmptySequence()
+    {
+        Array.Empty<int>()
+            .TryAggregate(
+                seed: 0,
+                func: (acc, item) => Ok<int, string>(acc + item))
+            .Should()
+            .BeOk(0);
+    }
 }


### PR DESCRIPTION
This PR introduces the `TryAggregate` method for the `Option` and `Result` types, enabling aggregation with built-in short-circuiting for failure cases.

#### **Key Features**

- **`TryAggregate` for `Option`:** Aggregates a sequence, returning `Some` on success or `None` on the first failure.
- **`TryAggregate` for `Result`:** Aggregates a sequence, propagating the first `Err` or returning the accumulated `Ok` value.

#### **Example Usage**

**Option**:
```csharp
var result = numbers.TryAggregate(0, (acc, item) => item > 0 ? Some(acc + item) : None);
// Returns: Some(x) or None
```

**Result**:
```csharp
var result = numbers.TryAggregate(0, (acc, item) => item < 5 ? Ok(acc + item) : Err("Too large"));
// Returns: Ok(x) or Err("Too large")
```

#### **Benefits**

- Simplifies conditional sequence aggregation.
- Reduces boilerplate for error propagation in `Option` and `Result`.

#### **Testing & Documentation**

- Comprehensive unit tests validate various scenarios.
- Documentation added for both `Option` and `Result`.